### PR TITLE
Hot fix for the saved sessions loop not working properly. This resets…

### DIFF
--- a/src/app/components/modals/videoplayer/videoplayer.component.ts
+++ b/src/app/components/modals/videoplayer/videoplayer.component.ts
@@ -235,16 +235,38 @@ export class VideoplayerComponent implements OnInit {
   onEnterCuePoint(textTrack) {
   }
 
+  // onExitCuePointMpbile (textTrack) {
+  //   if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+  //     let cue = textTrack.currentTarget;
+  //     VideoplayerComponent.api.seekTime(cue.endTime); 
+
+
+  //   }
+  // }
   onExitCuePoint(textTrack) {
     let cue = textTrack.currentTarget;
-    if (cue.loop && VideoplayerComponent.autoLoop) {
-      VideoplayerComponent.api.seekTime(cue.startTime);
-      if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
-      // turn off music here
-      VideoplayerComponent.api.volume = 0;
+    if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+      if (cue.loop && VideoplayerComponent.autoLoop) {
+        
+        VideoplayerComponent.api.seekTime(3);
+        if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
+        // turn off music here
+        VideoplayerComponent.api.volume = 0;
+      } else {
+        // Restore old volume here
+        if (VideoplayerComponent.originalVolume) VideoplayerComponent.api.volume = VideoplayerComponent.originalVolume;
+      }
     } else {
-      // Restore old volume here
-      if (VideoplayerComponent.originalVolume) VideoplayerComponent.api.volume = VideoplayerComponent.originalVolume;
+      if (cue.loop && VideoplayerComponent.autoLoop) {
+        
+        VideoplayerComponent.api.seekTime(10);
+        if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
+        // turn off music here
+        VideoplayerComponent.api.volume = 0;
+      } else {
+        // Restore old volume here
+        if (VideoplayerComponent.originalVolume) VideoplayerComponent.api.volume = VideoplayerComponent.originalVolume;
+      }
     }
   }
 

--- a/src/app/components/modals/videoplayer/videoplayer.component.ts
+++ b/src/app/components/modals/videoplayer/videoplayer.component.ts
@@ -234,13 +234,7 @@ export class VideoplayerComponent implements OnInit {
 
   onEnterCuePoint(textTrack) {
   }
-
-  // onExitCuePointMpbile (textTrack) {
-  //   if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-  //     let cue = textTrack.currentTarget;
-  //     VideoplayerComponent.api.seekTime(cue.endTime); 
-  //   }
-  // }
+  
   onExitCuePoint(textTrack) {
     let cue = textTrack.currentTarget;
     if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
@@ -260,10 +254,6 @@ export class VideoplayerComponent implements OnInit {
       }
     } else {
       if (cue.loop && VideoplayerComponent.autoLoop) {
-<<<<<<< HEAD
-=======
-        
->>>>>>> c61d9e6e5037952c485c207ea6f2c2a6ae6ee05a
         VideoplayerComponent.api.seekTime(cue.startTime);
         if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
         // turn off music here

--- a/src/app/components/modals/videoplayer/videoplayer.component.ts
+++ b/src/app/components/modals/videoplayer/videoplayer.component.ts
@@ -239,16 +239,18 @@ export class VideoplayerComponent implements OnInit {
   //   if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
   //     let cue = textTrack.currentTarget;
   //     VideoplayerComponent.api.seekTime(cue.endTime); 
-
-
   //   }
   // }
   onExitCuePoint(textTrack) {
     let cue = textTrack.currentTarget;
     if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
       if (cue.loop && VideoplayerComponent.autoLoop) {
-        
-        VideoplayerComponent.api.seekTime(3);
+
+        // smallest value of time which does not cause recursive buffering on iOS browsers is startTime+0.3s
+        var time = cue.startTime+ 0.3;
+        VideoplayerComponent.api.seekTime(time);
+
+        // This volume feature does not work yet, maybe save to a global variable?
         if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
         // turn off music here
         VideoplayerComponent.api.volume = 0;
@@ -258,8 +260,7 @@ export class VideoplayerComponent implements OnInit {
       }
     } else {
       if (cue.loop && VideoplayerComponent.autoLoop) {
-        
-        VideoplayerComponent.api.seekTime(10);
+        VideoplayerComponent.api.seekTime(cue.startTime);
         if (!VideoplayerComponent.originalVolume) VideoplayerComponent.originalVolume = VideoplayerComponent.api.volume; // save the old volume
         // turn off music here
         VideoplayerComponent.api.volume = 0;

--- a/src/app/components/modals/videoplayer/videoplayer.component.ts
+++ b/src/app/components/modals/videoplayer/videoplayer.component.ts
@@ -111,7 +111,7 @@ export class VideoplayerComponent implements OnInit {
 
   playPrevious() {
     if (this.selectedIndex === 0) return;
-    
+
     this.stopTimer();
 
     this.selectedIndex--;
@@ -234,14 +234,15 @@ export class VideoplayerComponent implements OnInit {
 
   onEnterCuePoint(textTrack) {
   }
-  
+
   onExitCuePoint(textTrack) {
     let cue = textTrack.currentTarget;
-    if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
       if (cue.loop && VideoplayerComponent.autoLoop) {
 
         // smallest value of time which does not cause recursive buffering on iOS browsers is startTime+0.3s
-        var time = cue.startTime+ 0.3;
+        var time = cue.startTime + 0.3;
         VideoplayerComponent.api.seekTime(time);
 
         // This volume feature does not work yet, maybe save to a global variable?


### PR DESCRIPTION
… the loop to a default 3 seconds instead of the marker start time. This works for most videos, however for some there is a small delay before proceeding to play the video